### PR TITLE
Adds net461 Target

### DIFF
--- a/CircularBuffer/CircularBuffer.csproj
+++ b/CircularBuffer/CircularBuffer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/joaoportela/CircularBuffer-CSharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Per best practices, when targeting `netstandard2.0`, a `net461` should be included (https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting).

Functionally, this prevents needing to reference all of `netstandard2.0` in .NET Framework (and prevents bugs in older version of .NET Framework). With modern .NET tooling, this should continue to build fine under Linux and friends.