### PR TITLE
Some improvements

### DIFF
--- a/CircularBuffer.Tests/CircularBufferTests.cs
+++ b/CircularBuffer.Tests/CircularBufferTests.cs
@@ -20,7 +20,7 @@ namespace CircularBuffer.Tests
             var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3 });
 
             Assert.That(buffer.Capacity, Is.EqualTo(5));
-            Assert.That(buffer.Size, Is.EqualTo(4));
+            Assert.That(buffer.Count, Is.EqualTo(4));
             for (int i = 0; i < 4; i++)
             {
                 Assert.That(buffer[i], Is.EqualTo(i));
@@ -57,7 +57,7 @@ namespace CircularBuffer.Tests
                 buffer.PushBack(i);
             }
 
-            Assert.That(buffer.Front(), Is.EqualTo(0));
+            Assert.That(buffer.First(), Is.EqualTo(0));
             for (int i = 0; i < 5; i++)
             {
                 Assert.That(buffer[i], Is.EqualTo(i));
@@ -118,6 +118,99 @@ namespace CircularBuffer.Tests
         }
 
         [Test]
+        public void CircularBuffer_CopyToConstructorDefinedArray_Exceptions()
+        {
+            var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3, 4 });
+
+            Assert.Throws<ArgumentNullException>(() => buffer.CopyTo(null));
+
+            var array = new int[5];
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.CopyTo(array, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.CopyTo(array, -1L));
+
+            Assert.Throws<ArgumentException>(() => buffer.CopyTo(array, 1));
+            Assert.Throws<ArgumentException>(() => buffer.CopyTo(array, 1L));
+
+            array = new int[4];
+
+            Assert.Throws<ArgumentException>(() => buffer.CopyTo(array));
+
+#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
+
+            array = new int[5];
+            Assert.Throws<ArgumentException>(() => buffer.CopyTo(array.AsMemory(1)));
+            Assert.Throws<ArgumentException>(() => buffer.CopyTo(array.AsSpan(1)));
+
+#endif
+        }
+
+        [Test]
+        public void CircularBuffer_CopyToConstructorDefinedArray_CorrectContent()
+        {
+            var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3 });
+
+            var array = new int[4];
+            buffer.CopyTo(array);
+            Assert.That(array, Is.EqualTo(new[] { 0, 1, 2, 3 }));
+
+            array = new int[5];
+            buffer.CopyTo(array, 1);
+            Assert.That(array, Is.EqualTo(new[] { 0, 0, 1, 2, 3 }));
+
+            array = new int[5];
+            buffer.CopyTo(array, 1L);
+            Assert.That(array, Is.EqualTo(new[] { 0, 0, 1, 2, 3 }));
+
+#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
+
+            array = new int[5];
+            buffer.CopyTo(array.AsMemory(1));
+            Assert.That(array, Is.EqualTo(new[] { 0, 0, 1, 2, 3 }));
+
+            array = new int[5];
+            buffer.CopyTo(array.AsSpan(1));
+            Assert.That(array, Is.EqualTo(new[] { 0, 0, 1, 2, 3 }));
+
+#endif
+        }
+
+        [Test]
+        public void CircularBuffer_CopyToOverflowedBuffer_CorrectContent()
+        {
+            var buffer = new CircularBuffer<int>(5);
+
+            for (int i = 0; i < 10; i++)
+            {
+                buffer.PushBack(i);
+            }
+
+            var array = new int[5];
+            buffer.CopyTo(array);
+            Assert.That(array, Is.EqualTo(new[] { 5, 6, 7, 8, 9 }));
+
+            array = new int[6];
+            buffer.CopyTo(array, 1);
+            Assert.That(array, Is.EqualTo(new[] { 0, 5, 6, 7, 8, 9 }));
+
+            array = new int[6];
+            buffer.CopyTo(array, 1L);
+            Assert.That(array, Is.EqualTo(new[] { 0, 5, 6, 7, 8, 9 }));
+
+#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
+
+            array = new int[6];
+            buffer.CopyTo(array.AsMemory(1));
+            Assert.That(array, Is.EqualTo(new[] { 0, 5, 6, 7, 8, 9 }));
+
+            array = new int[6];
+            buffer.CopyTo(array.AsSpan(1));
+            Assert.That(array, Is.EqualTo(new[] { 0, 5, 6, 7, 8, 9 }));
+
+#endif
+        }
+
+        [Test]
         public void CircularBuffer_ToArraySegmentsConstructorDefinedArray_CorrectContent()
         {
             var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3 });
@@ -142,6 +235,76 @@ namespace CircularBuffer.Tests
             Assert.That(arraySegments.Count, Is.EqualTo(2)); // length of 2 is part of the contract.
             Assert.That(arraySegments.SelectMany(x => x), Is.EqualTo(new[] { 5, 6, 7, 8, 9 }));
         }
+
+#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
+
+        [Test]
+        public void CircularBuffer_ToMemoryConstructorDefinedArray_CorrectContent()
+        {
+            var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3 });
+
+            var (memoryA, memoryB) = buffer.ToMemory();
+
+            var array = new int[4];
+            memoryA.CopyTo(array.AsMemory());
+            memoryB.CopyTo(array.AsMemory(memoryA.Length));
+
+            Assert.That(array, Is.EqualTo(new[] { 0, 1, 2, 3 }));
+        }
+
+        [Test]
+        public void CircularBuffer_ToMemoryOverflowedBuffer_CorrectContent()
+        {
+            var buffer = new CircularBuffer<int>(5);
+
+            for (int i = 0; i < 10; i++)
+            {
+                buffer.PushBack(i);
+            }
+
+            var (memoryA, memoryB) = buffer.ToMemory();
+
+            var array = new int[5];
+            memoryA.CopyTo(array.AsMemory());
+            memoryB.CopyTo(array.AsMemory(memoryA.Length));
+
+            Assert.That(array, Is.EqualTo(new[] { 5, 6, 7, 8, 9 }));
+        }
+
+        [Test]
+        public void CircularBuffer_ToSpanConstructorDefinedArray_CorrectContent()
+        {
+            var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3 });
+
+            var (spanA, spanB) = buffer.ToSpan();
+
+            var array = new int[4];
+            spanA.CopyTo(array.AsSpan());
+            spanB.CopyTo(array.AsSpan(spanA.Length));
+
+            Assert.That(array, Is.EqualTo(new[] { 0, 1, 2, 3 }));
+        }
+
+        [Test]
+        public void CircularBuffer_ToSpanOverflowedBuffer_CorrectContent()
+        {
+            var buffer = new CircularBuffer<int>(5);
+
+            for (int i = 0; i < 10; i++)
+            {
+                buffer.PushBack(i);
+            }
+
+            var (spanA, spanB) = buffer.ToSpan();
+
+            var array = new int[5];
+            spanA.CopyTo(array.AsSpan());
+            spanB.CopyTo(array.AsSpan(spanA.Length));
+
+            Assert.That(array, Is.EqualTo(new[] { 5, 6, 7, 8, 9 }));
+        }
+
+#endif
 
         [Test]
         public void CircularBuffer_PushFront_CorrectContent()
@@ -174,14 +337,14 @@ namespace CircularBuffer.Tests
         {
             var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3, 4 });
 
-            Assert.That(buffer.Front(), Is.EqualTo(0));
+            Assert.That(buffer.First(), Is.EqualTo(0));
         }
 
         [Test]
         public void CircularBuffer_Back_CorrectItem()
         {
             var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3, 4 });
-            Assert.That(buffer.Back(), Is.EqualTo(4));
+            Assert.That(buffer.Last(), Is.EqualTo(4));
         }
 
         [Test]
@@ -190,7 +353,7 @@ namespace CircularBuffer.Tests
             var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3, 4 });
             buffer.PushBack(42);
             Assert.That(buffer.ToArray(), Is.EqualTo(new[] { 1, 2, 3, 4, 42 }));
-            Assert.That(buffer.Back(), Is.EqualTo(42));
+            Assert.That(buffer.Last(), Is.EqualTo(42));
         }
 
         [Test]
@@ -198,7 +361,7 @@ namespace CircularBuffer.Tests
         {
             var buffer = new CircularBuffer<int>(5);
 
-            Assert.That(() => buffer.Front(),
+            Assert.That(() => buffer.First(),
                          Throws.Exception.TypeOf<InvalidOperationException>().
                          With.Property("Message").Contains("empty buffer"));
         }
@@ -207,7 +370,7 @@ namespace CircularBuffer.Tests
         public void CircularBuffer_Back_EmptyBufferThrowsException()
         {
             var buffer = new CircularBuffer<int>(5);
-            Assert.That(() => buffer.Back(),
+            Assert.That(() => buffer.Last(),
                          Throws.Exception.TypeOf<InvalidOperationException>().
                          With.Property("Message").Contains("empty buffer"));
         }
@@ -217,11 +380,11 @@ namespace CircularBuffer.Tests
         {
             var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3, 4 });
 
-            Assert.That(buffer.Size, Is.EqualTo(5));
+            Assert.That(buffer.Count, Is.EqualTo(5));
 
             buffer.PopBack();
 
-            Assert.That(buffer.Size, Is.EqualTo(4));
+            Assert.That(buffer.Count, Is.EqualTo(4));
             Assert.That(buffer.ToArray(), Is.EqualTo(new[] { 0, 1, 2, 3 }));
         }
 
@@ -231,12 +394,12 @@ namespace CircularBuffer.Tests
             var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3, 4 });
             buffer.PushBack(5);
 
-            Assert.That(buffer.Size, Is.EqualTo(5));
+            Assert.That(buffer.Count, Is.EqualTo(5));
             Assert.That(buffer.ToArray(), Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
 
             buffer.PopBack();
 
-            Assert.That(buffer.Size, Is.EqualTo(4));
+            Assert.That(buffer.Count, Is.EqualTo(4));
             Assert.That(buffer.ToArray(), Is.EqualTo(new[] { 1, 2, 3, 4 }));
         }
 
@@ -245,11 +408,11 @@ namespace CircularBuffer.Tests
         {
             var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3, 4 });
 
-            Assert.That(buffer.Size, Is.EqualTo(5));
+            Assert.That(buffer.Count, Is.EqualTo(5));
 
             buffer.PopFront();
 
-            Assert.That(buffer.Size, Is.EqualTo(4));
+            Assert.That(buffer.Count, Is.EqualTo(4));
             Assert.That(buffer.ToArray(), Is.EqualTo(new[] { 1, 2, 3, 4 }));
         }
 
@@ -259,12 +422,12 @@ namespace CircularBuffer.Tests
             var buffer = new CircularBuffer<int>(5, new[] { 0, 1, 2, 3, 4 });
             buffer.PushFront(5);
 
-            Assert.That(buffer.Size, Is.EqualTo(5));
+            Assert.That(buffer.Count, Is.EqualTo(5));
             Assert.That(buffer.ToArray(), Is.EqualTo(new[] { 5, 0, 1, 2, 3 }));
 
             buffer.PopFront();
 
-            Assert.That(buffer.Size, Is.EqualTo(4));
+            Assert.That(buffer.Count, Is.EqualTo(4));
             Assert.That(buffer.ToArray(), Is.EqualTo(new[] { 0, 1, 2, 3 }));
         }
 
@@ -289,7 +452,7 @@ namespace CircularBuffer.Tests
 
             buffer.PopFront(); // (make size and capacity different)
 
-            Assert.That(buffer.Back(), Is.EqualTo(4));
+            Assert.That(buffer.Last(), Is.EqualTo(4));
         }
 
         [Test]
@@ -299,7 +462,7 @@ namespace CircularBuffer.Tests
 
             buffer.Clear();
 
-            Assert.That(buffer.Size, Is.EqualTo(0));
+            Assert.That(buffer.Count, Is.EqualTo(0));
             Assert.That(buffer.Capacity, Is.EqualTo(5));
             Assert.That(buffer.ToArray(), Is.EqualTo(new int[0]));
         }
@@ -315,7 +478,7 @@ namespace CircularBuffer.Tests
                 buffer.PushBack(i);
             }
 
-            Assert.That(buffer.Front(), Is.EqualTo(0));
+            Assert.That(buffer.First(), Is.EqualTo(0));
             for (int i = 0; i < 5; i++)
             {
                 Assert.That(buffer[i], Is.EqualTo(i));

--- a/CircularBuffer/CircularBuffer.cs
+++ b/CircularBuffer/CircularBuffer.cs
@@ -16,7 +16,7 @@ namespace CircularBuffer
     /// http://www.boost.org/doc/libs/1_53_0/libs/circular_buffer/doc/circular_buffer.html
     /// because I liked their interface.
     /// </summary>
-    public class CircularBuffer<T> : IEnumerable<T>
+    public class CircularBuffer<T> : IReadOnlyCollection<T>
     {
         private readonly T[] _buffer;
 
@@ -120,6 +120,8 @@ namespace CircularBuffer
         /// Current buffer size (the number of elements that the buffer has).
         /// </summary>
         public int Size { get { return _size; } }
+
+        int IReadOnlyCollection<T>.Count => Size;
 
         /// <summary>
         /// Element at the front of the buffer - this[0].

--- a/CircularBuffer/CircularBuffer.cs
+++ b/CircularBuffer/CircularBuffer.cs
@@ -5,18 +5,7 @@ using System.Collections.Generic;
 namespace CircularBuffer
 {
     /// <inheritdoc/>
-    /// <summary>
-    /// Circular buffer.
-    /// 
-    /// When writing to a full buffer:
-    /// PushBack -> removes this[0] / Front()
-    /// PushFront -> removes this[Size-1] / Back()
-    /// 
-    /// this implementation is inspired by
-    /// http://www.boost.org/doc/libs/1_53_0/libs/circular_buffer/doc/circular_buffer.html
-    /// because I liked their interface.
-    /// </summary>
-    public class CircularBuffer<T> : IReadOnlyCollection<T>
+    public class CircularBuffer<T> : ICircularBuffer<T>
     {
         private readonly T[] _buffer;
 
@@ -85,18 +74,10 @@ namespace CircularBuffer
             _end = _size == capacity ? 0 : _size;
         }
 
-        /// <summary>
-        /// Maximum capacity of the buffer. Elements pushed into the buffer after
-        /// maximum capacity is reached (IsFull = true), will remove an element.
-        /// </summary>
+        /// <inheritdoc/>
         public int Capacity { get { return _buffer.Length; } }
 
-        /// <summary>
-        /// Boolean indicating if Circular is at full capacity.
-        /// Adding more elements when the buffer is full will
-        /// cause elements to be removed from the other end
-        /// of the buffer.
-        /// </summary>
+        /// <inheritdoc/>
         public bool IsFull
         {
             get
@@ -105,9 +86,7 @@ namespace CircularBuffer
             }
         }
 
-        /// <summary>
-        /// True if has no elements.
-        /// </summary>
+        /// <inheritdoc/>
         public bool IsEmpty
         {
             get
@@ -116,40 +95,26 @@ namespace CircularBuffer
             }
         }
 
-        /// <summary>
-        /// Current buffer size (the number of elements that the buffer has).
-        /// </summary>
+        /// <inheritdoc/>
         public int Size { get { return _size; } }
 
         int IReadOnlyCollection<T>.Count => Size;
 
-        /// <summary>
-        /// Element at the front of the buffer - this[0].
-        /// </summary>
-        /// <returns>The value of the element of type T at the front of the buffer.</returns>
+        /// <inheritdoc/>
         public T Front()
         {
             ThrowIfEmpty();
             return _buffer[_start];
         }
 
-        /// <summary>
-        /// Element at the back of the buffer - this[Size - 1].
-        /// </summary>
-        /// <returns>The value of the element of type T at the back of the buffer.</returns>
+        /// <inheritdoc/>
         public T Back()
         {
             ThrowIfEmpty();
             return _buffer[(_end != 0 ? _end : Capacity) - 1];
         }
 
-        /// <summary>
-        /// Index access to elements in buffer.
-        /// Index does not loop around like when adding elements,
-        /// valid interval is [0;Size[
-        /// </summary>
-        /// <param name="index">Index of element to access.</param>
-        /// <exception cref="IndexOutOfRangeException">Thrown when index is outside of [; Size[ interval.</exception>
+        /// <inheritdoc/>
         public T this[int index]
         {
             get
@@ -180,14 +145,7 @@ namespace CircularBuffer
             }
         }
 
-        /// <summary>
-        /// Pushes a new element to the back of the buffer. Back()/this[Size-1]
-        /// will now return this element.
-        /// 
-        /// When the buffer is full, the element at Front()/this[0] will be 
-        /// popped to allow for this new element to fit.
-        /// </summary>
-        /// <param name="item">Item to push to the back of the buffer</param>
+        /// <inheritdoc/>
         public void PushBack(T item)
         {
             if (IsFull)
@@ -204,14 +162,7 @@ namespace CircularBuffer
             }
         }
 
-        /// <summary>
-        /// Pushes a new element to the front of the buffer. Front()/this[0]
-        /// will now return this element.
-        /// 
-        /// When the buffer is full, the element at Back()/this[Size-1] will be 
-        /// popped to allow for this new element to fit.
-        /// </summary>
-        /// <param name="item">Item to push to the front of the buffer</param>
+        /// <inheritdoc/>
         public void PushFront(T item)
         {
             if (IsFull)
@@ -228,10 +179,7 @@ namespace CircularBuffer
             }
         }
 
-        /// <summary>
-        /// Removes the element at the back of the buffer. Decreasing the 
-        /// Buffer size by 1.
-        /// </summary>
+        /// <inheritdoc/>
         public void PopBack()
         {
             ThrowIfEmpty("Cannot take elements from an empty buffer.");
@@ -240,10 +188,7 @@ namespace CircularBuffer
             --_size;
         }
 
-        /// <summary>
-        /// Removes the element at the front of the buffer. Decreasing the 
-        /// Buffer size by 1.
-        /// </summary>
+        /// <inheritdoc/>
         public void PopFront()
         {
             ThrowIfEmpty("Cannot take elements from an empty buffer.");
@@ -252,10 +197,7 @@ namespace CircularBuffer
             --_size;
         }
 
-        /// <summary>
-        /// Clears the contents of the array. Size = 0, Capacity is unchanged.
-        /// </summary>
-        /// <exception cref="NotImplementedException"></exception>
+        /// <inheritdoc/>
         public void Clear()
         {
             // to clear we just reset everything.
@@ -265,12 +207,7 @@ namespace CircularBuffer
             Array.Clear(_buffer, 0, _buffer.Length);
         }
 
-        /// <summary>
-        /// Copies the buffer contents to an array, according to the logical
-        /// contents of the buffer (i.e. independent of the internal 
-        /// order/contents)
-        /// </summary>
-        /// <returns>A new array with a copy of the buffer contents.</returns>
+        /// <inheritdoc/>
         public T[] ToArray()
         {
             T[] newArray = new T[Size];
@@ -284,21 +221,10 @@ namespace CircularBuffer
             return newArray;
         }
 
-        /// <summary>
-        /// Get the contents of the buffer as 2 ArraySegments.
-        /// Respects the logical contents of the buffer, where
-        /// each segment and items in each segment are ordered
-        /// according to insertion.
-        ///
-        /// Fast: does not copy the array elements.
-        /// Useful for methods like <c>Send(IList&lt;ArraySegment&lt;Byte&gt;&gt;)</c>.
-        /// 
-        /// <remarks>Segments may be empty.</remarks>
-        /// </summary>
-        /// <returns>An IList with 2 segments corresponding to the buffer content.</returns>
+        /// <inheritdoc/>
         public IList<ArraySegment<T>> ToArraySegments()
         {
-            return new [] { ArrayOne(), ArrayTwo() };
+            return new[] { ArrayOne(), ArrayTwo() };
         }
 
         #region IEnumerable<T> implementation

--- a/CircularBuffer/CircularBuffer.csproj
+++ b/CircularBuffer/CircularBuffer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/joaoportela/CircularBuffer-CSharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -17,7 +17,7 @@
     <None Include="..\LICENSE" Pack="true" PackagePath="LICENSE" />
   </ItemGroup>
 
-  <ItemGroup> 
+  <ItemGroup>
     <None Include="..\doc\logo.png">
       <Pack>true</Pack>
       <Visible>false</Visible>

--- a/CircularBuffer/ICircularBuffer.cs
+++ b/CircularBuffer/ICircularBuffer.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+
+namespace CircularBuffer
+{
+    /// <summary>
+    /// Circular buffer.
+    ///
+    /// When writing to a full buffer:
+    /// PushBack -> removes this[0] / Front()
+    /// PushFront -> removes this[Size-1] / Back()
+    ///
+    /// this implementation is inspired by
+    /// http://www.boost.org/doc/libs/1_53_0/libs/circular_buffer/doc/circular_buffer.html
+    /// because I liked their interface.
+    /// </summary>
+    public interface ICircularBuffer<T> : IReadOnlyCollection<T>
+    {
+        /// <summary>
+        /// Index access to elements in buffer.
+        /// Index does not loop around like when adding elements,
+        /// valid interval is [0;Size[
+        /// </summary>
+        /// <param name="index">Index of element to access.</param>
+        /// <exception cref="IndexOutOfRangeException">Thrown when index is outside of [; Size[ interval.</exception>
+        T this[int index] { get; set; }
+
+        /// <summary>
+        /// Maximum capacity of the buffer. Elements pushed into the buffer after
+        /// maximum capacity is reached (IsFull = true), will remove an element.
+        /// </summary>
+        int Capacity { get; }
+
+        /// <summary>
+        /// Boolean indicating if Circular is at full capacity.
+        /// Adding more elements when the buffer is full will
+        /// cause elements to be removed from the other end
+        /// of the buffer.
+        /// </summary>
+        bool IsFull { get; }
+
+        /// <summary>
+        /// True if has no elements.
+        /// </summary>
+        bool IsEmpty { get; }
+
+        /// <summary>
+        /// Current buffer size (the number of elements that the buffer has).
+        /// </summary>
+        int Size { get; }
+
+        /// <summary>
+        /// Element at the back of the buffer - this[Size - 1].
+        /// </summary>
+        /// <returns>The value of the element of type T at the back of the buffer.</returns>
+        T Back();
+
+        /// <summary>
+        /// Element at the front of the buffer - this[0].
+        /// </summary>
+        /// <returns>The value of the element of type T at the front of the buffer.</returns>
+        T Front();
+
+        /// <summary>
+        /// Clears the contents of the array. Size = 0, Capacity is unchanged.
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        void Clear();
+
+        /// <summary>
+        /// Removes the element at the back of the buffer. Decreasing the 
+        /// Buffer size by 1.
+        /// </summary>
+        void PopBack();
+
+        /// <summary>
+        /// Removes the element at the front of the buffer. Decreasing the 
+        /// Buffer size by 1.
+        /// </summary>
+        void PopFront();
+
+        /// <summary>
+        /// Pushes a new element to the back of the buffer. Back()/this[Size-1]
+        /// will now return this element.
+        ///
+        /// When the buffer is full, the element at Front()/this[0] will be
+        /// popped to allow for this new element to fit.
+        /// </summary>
+        /// <param name="item">Item to push to the back of the buffer</param>
+        void PushBack(T item);
+
+        /// <summary>
+        /// Pushes a new element to the front of the buffer. Front()/this[0]
+        /// will now return this element.
+        ///
+        /// When the buffer is full, the element at Back()/this[Size-1] will be
+        /// popped to allow for this new element to fit.
+        /// </summary>
+        /// <param name="item">Item to push to the front of the buffer</param>
+        void PushFront(T item);
+
+        /// <summary>
+        /// Copies the buffer contents to an array, according to the logical
+        /// contents of the buffer (i.e. independent of the internal 
+        /// order/contents)
+        /// </summary>
+        /// <returns>A new array with a copy of the buffer contents.</returns>
+        T[] ToArray();
+
+        /// <summary>
+        /// Get the contents of the buffer as 2 ArraySegments.
+        /// Respects the logical contents of the buffer, where
+        /// each segment and items in each segment are ordered
+        /// according to insertion.
+        ///
+        /// Fast: does not copy the array elements.
+        /// Useful for methods like <c>Send(IList&lt;ArraySegment&lt;Byte&gt;&gt;)</c>.
+        ///
+        /// <remarks>Segments may be empty.</remarks>
+        /// </summary>
+        /// <returns>An IList with 2 segments corresponding to the buffer content.</returns>
+        IList<ArraySegment<T>> ToArraySegments();
+    }
+}

--- a/CircularBuffer/ICircularBuffer.cs
+++ b/CircularBuffer/ICircularBuffer.cs
@@ -47,19 +47,34 @@ namespace CircularBuffer
         /// <summary>
         /// Current buffer size (the number of elements that the buffer has).
         /// </summary>
+        [Obsolete("Use Count property instead")]
         int Size { get; }
 
         /// <summary>
         /// Element at the back of the buffer - this[Size - 1].
         /// </summary>
         /// <returns>The value of the element of type T at the back of the buffer.</returns>
+        [Obsolete("Use Last() method instead")]
         T Back();
 
         /// <summary>
         /// Element at the front of the buffer - this[0].
         /// </summary>
         /// <returns>The value of the element of type T at the front of the buffer.</returns>
+        [Obsolete("Use First() method instead")]
         T Front();
+
+        /// <summary>
+        /// Element at the back of the buffer - this[Size - 1].
+        /// </summary>
+        /// <returns>The value of the element of type T at the back of the buffer.</returns>
+        T First();
+
+        /// <summary>
+        /// Element at the front of the buffer - this[0].
+        /// </summary>
+        /// <returns>The value of the element of type T at the front of the buffer.</returns>
+        T Last();
 
         /// <summary>
         /// Clears the contents of the array. Size = 0, Capacity is unchanged.
@@ -101,11 +116,57 @@ namespace CircularBuffer
 
         /// <summary>
         /// Copies the buffer contents to an array, according to the logical
-        /// contents of the buffer (i.e. independent of the internal 
+        /// contents of the buffer (i.e. independent of the internal
         /// order/contents)
         /// </summary>
         /// <returns>A new array with a copy of the buffer contents.</returns>
         T[] ToArray();
+
+        /// <summary>
+        /// Copies the buffer contents to the array, according to the logical
+        /// contents of the buffer (i.e. independent of the internal
+        /// order/contents)
+        /// </summary>
+        /// <param name="array">The array that is the destination of the elements copied from the current buffer.</param>
+        void CopyTo(T[] array);
+
+        /// <summary>
+        /// Copies the buffer contents to the array, according to the logical
+        /// contents of the buffer (i.e. independent of the internal
+        /// order/contents)
+        /// </summary>
+        /// <param name="array">The array that is the destination of the elements copied from the current buffer.</param>
+        /// <param name="index">A 32-bit integer that represents the index in array at which copying begins.</param>
+        void CopyTo(T[] array, int index);
+
+        /// <summary>
+        /// Copies the buffer contents to the array, according to the logical
+        /// contents of the buffer (i.e. independent of the internal
+        /// order/contents)
+        /// </summary>
+        /// <param name="array">The array that is the destination of the elements copied from the current buffer.</param>
+        /// <param name="index">A 64-bit integer that represents the index in array at which copying begins.</param>
+        void CopyTo(T[] array, long index);
+
+#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
+
+        /// <summary>
+        /// Copies the buffer contents to the <see cref="Memory&lt;T&gt;"/>, according to the logical
+        /// contents of the buffer (i.e. independent of the internal
+        /// order/contents)
+        /// </summary>
+        /// <param name="memory">The memory that is the destination of the elements copied from the current buffer.</param>
+        void CopyTo(Memory<T> memory);
+
+        /// <summary>
+        /// Copies the buffer contents to the <see cref="Span&lt;T&gt;"/>, according to the logical
+        /// contents of the buffer (i.e. independent of the internal
+        /// order/contents)
+        /// </summary>
+        /// <param name="span">The span that is the destination of the elements copied from the current buffer.</param>
+        void CopyTo(Span<T> span);
+
+#endif
 
         /// <summary>
         /// Get the contents of the buffer as 2 ArraySegments.
@@ -120,5 +181,31 @@ namespace CircularBuffer
         /// </summary>
         /// <returns>An IList with 2 segments corresponding to the buffer content.</returns>
         IList<ArraySegment<T>> ToArraySegments();
+
+#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
+
+        /// <summary>
+        /// Get the contents of the buffer as ref struct with 2 read only spans (<see cref="SpanTuple&lt;T&gt;"/>).
+        /// Respects the logical contents of the buffer, where
+        /// each segment and items in each segment are ordered
+        /// according to insertion.
+        ///
+        /// <remarks>Segments may be empty.</remarks>
+        /// </summary>
+        /// <returns>A <see cref="SpanTuple&lt;T&gt;"/> with 2 read only spans corresponding to the buffer content.</returns>
+        SpanTuple<T> ToSpan();
+
+        /// <summary>
+        /// Get the contents of the buffer as tuple with 2 <see cref="ReadOnlyMemory&lt;T&gt;"/>.
+        /// Respects the logical contents of the buffer, where
+        /// each segment and items in each segment are ordered
+        /// according to insertion.
+        ///
+        /// <remarks>Segments may be empty.</remarks>
+        /// </summary>
+        /// <returns>A tuple with 2 read only spans corresponding to the buffer content.</returns>
+        (ReadOnlyMemory<T> A, ReadOnlyMemory<T> B) ToMemory();
+
+#endif
     }
 }

--- a/CircularBuffer/SpanTuple.cs
+++ b/CircularBuffer/SpanTuple.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace CircularBuffer
+{
+
+#if (NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
+
+    /// <summary>
+    /// Reference struct that contains two read only spans of type T
+    /// </summary>
+    public ref struct SpanTuple<T>
+    {
+        /// <summary>
+        /// First span
+        /// </summary>
+        public ReadOnlySpan<T> A { get; }
+
+        /// <summary>
+        /// Second span
+        /// </summary>
+        public ReadOnlySpan<T> B { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="a">First span</param>
+        /// <param name="b">Second span</param>
+        public SpanTuple(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
+        {
+            A = a;
+            B = b;
+        }
+
+        /// <summary>
+        /// Deconstructs the current <see cref="SpanTuple&lt;T&gt;"/>
+        /// </summary>
+        /// <param name="a">First span target</param>
+        /// <param name="b">Second span target</param>
+        public void Deconstruct(out ReadOnlySpan<T> a, out ReadOnlySpan<T> b)
+        {
+            a = A;
+            b = B;
+        }
+    }
+
+#endif
+
+}


### PR DESCRIPTION
Added interface ICircularBuffer;
Implemented IReadOnlyCollection<T> instead of just IEnumerable;
Size, Front, Back renamed to Count, First, Last an marked as obsolete, as was described into https://github.com/joaoportela/CircularBuffer-CSharp/issues/52;
Added CopyTo methods;
Added support of Span / Memory for supported frameworks versions;